### PR TITLE
fix: stop using previously disabled frontend extender

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -13,4 +13,4 @@ app.initializers.add('fof-moderator-notes', () => {
   addModeratorNotesPage();
 });
 
-export const extend = [new Extend.Model('moderatorNotes', ModeratorNote)];
+export const extend = [new Extend.Store().add('moderatorNotes', ModeratorNote)];


### PR DESCRIPTION
Surprisingly it seems like this is old enough that it used to use a frontend extender from back when they still kind of worked.
This fails in v1.7