### PR TITLE
fix(routing): use slug for routing on UserPage

### DIFF
--- a/js/src/forum/addModeratorNotesPage.js
+++ b/js/src/forum/addModeratorNotesPage.js
@@ -18,7 +18,7 @@ export default function () {
         'notes',
         LinkButton.component(
           {
-            href: app.route('user.notes', { username: this.user.username() }),
+            href: app.route('user.notes', { username: this.user.slug() }),
             icon: 'fas fa-sticky-note',
           },
           [


### PR DESCRIPTION
Summary:
- Use slug instead of username to ensure compatibility no matter if the slug driver is left to default or id.